### PR TITLE
cli: redo & fix shell completions

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -73,10 +73,10 @@
           nativeBuildInputs = [pkgs.installShellFiles];
           doCheck = true;
           postInstall = ''
-            $out/bin/wire apply --generate-completions bash > wire.bash
-            $out/bin/wire apply --generate-completions fish > wire.fish
-            $out/bin/wire apply --generate-completions zsh > wire.zsh
-            installShellCompletion wire.{bash,fish,zsh}
+            installShellCompletion --cmd wire \
+                --bash <($out/bin/wire completions bash) \
+                --fish <($out/bin/wire completions fish) \
+                --zsh <($out/bin/wire completions zsh)
           '';
         });
     };

--- a/wire/cli/src/cli.rs
+++ b/wire/cli/src/cli.rs
@@ -1,12 +1,10 @@
-use clap::{value_parser, Command, Parser, Subcommand, ValueEnum};
-use clap_complete::aot::{generate, Generator};
+use clap::{Parser, Subcommand, ValueEnum};
 use clap_complete::Shell;
 use clap_num::number_range;
 use clap_verbosity_flag::WarnLevel;
 use lib::hive::node::{Goal as HiveGoal, Name, SwitchToConfigurationGoal};
 use lib::SubCommandModifiers;
 
-use std::io;
 use std::{
     fmt::{self, Display, Formatter},
     sync::Arc,
@@ -39,9 +37,6 @@ pub struct Cli {
 
     #[arg(long, hide = true, global = true)]
     pub markdown_help: bool,
-
-    #[arg(long, hide = true, global = true, value_parser = value_parser!(Shell))]
-    pub generate_completions: Option<Shell>,
 }
 
 #[derive(Clone, Debug)]
@@ -114,6 +109,12 @@ pub enum Commands {
         #[arg(default_value_t = 0)]
         index: i32,
     },
+    /// Generates shell completions
+    Completions {
+        #[arg()]
+        // Shell to generate completions for
+        shell: Shell,
+    },
 }
 
 #[derive(Clone, Debug, Default, ValueEnum, Display)]
@@ -169,8 +170,4 @@ impl ToSubCommandModifiers for Cli {
             show_trace: self.show_trace,
         }
     }
-}
-
-pub fn print_completions<G: Generator>(gen: G, cmd: &mut Command) {
-    generate(gen, cmd, cmd.get_name().to_string(), &mut io::stdout());
 }


### PR DESCRIPTION
Fixes completions from not being present and moves completions into its own subcommand to make it cleaner.

In order to test if the completions work or not you have to add this to your system/home closure, simply doing `nix shell .` will not add the completions.
