### PR TITLE
runtime/evaluate.nix: force system to be null

### DIFF
--- a/runtime/evaluate.nix
+++ b/runtime/evaluate.nix
@@ -52,7 +52,7 @@ let
         mergedHive.defaults
         mergedHive.${name}
       ];
-
+      system = null;
       specialArgs = {
         inherit name nodes;
       } // mergedHive.meta.specialArgs or { };


### PR DESCRIPTION
Users should set `nixpkgs.hostPlatform` modularly instead