### PR TITLE
drop mdformat and yamlfmt for prettier

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+[*]
+charset = utf-8
+insert_final_newline = true
+end_of_line = lf
+indent_style = space
+indent_size = 2
+max_line_length = 80
+
+[*.rs]
+indent_size = 4

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,14 @@
+.direnv
+.pre-commit-config.yaml
+**/flake.lock
+
+**/pnpm-lock.yaml
+
+**/.vitepress/cache
+**/.vitepress/dist
+
+**/result
+**/target
+
+**/.git
+**/node_modules

--- a/doc/guide/wire.md
+++ b/doc/guide/wire.md
@@ -1,8 +1,8 @@
 # What is Wire?
 
-Wire is a tool to deploy NixOS systems. Its configuration is a superset\[^1\] of [colmena](https://colmena.cli.rs/), however it is **not** a fork.
+Wire is a tool to deploy NixOS systems. Its configuration is a superset[^1] of [colmena](https://colmena.cli.rs/), however it is **not** a fork.
 
-\[^1\]: Any colmena configuration will continue to work with wire, but wire has additional ergonomic changes you can take advantage of.
+[^1]: Any colmena configuration will continue to work with wire, but wire has additional ergonomic changes you can take advantage of.
 
 ::: warning
 Wire is alpha software, please use at your own risk. Many features listed in this documentation may not be complete / implemented.
@@ -25,7 +25,7 @@ The following is the goal for a stable release and not fully implemented.
 | Secret Management     | :white_check_mark:           | :white_check_mark:                                                                                         |
 | Parallel Evaluation   | :white_check_mark:           | [Experimental](https://colmena.cli.rs/unstable/features/parallelism.html#parallel-evaluation-experimental) |
 | Node Tagging          | :white_check_mark:           | :white_check_mark:                                                                                         |
-| `jq` pipeline support | :white_check_mark:           | :x:\[^2\]                                                                                                  |
+| `jq` pipeline support | :white_check_mark:           | :x:[^2]                                                                                                    |
 | Magic Rollback        | :white_check_mark: (Planned) | :x:                                                                                                        |
 
-\[^2\]: You need to write custom nix code to use Colmena hive metadata inside environments like CI pipelines, bash scripting, etc., which requires a knowledge of its internals.
+[^2]: You need to write custom nix code to use Colmena hive metadata inside environments like CI pipelines, bash scripting, etc., which requires a knowledge of its internals.

--- a/flake.nix
+++ b/flake.nix
@@ -51,20 +51,12 @@
               nixfmt.enable = true;
 
               rustfmt.enable = true;
-              yamlfmt.enable = true;
               just.enable = true;
-              mdformat = {
-                enable = true;
-                package = pkgs.mdformat.withPlugins (plugins: [ plugins.mdformat-frontmatter ]);
-              };
               prettier.enable = true;
               protolint.enable = true;
               taplo.enable = true;
             };
-            settings.global.excludes = [ "**/pnpm-lock.yaml" ];
-
           };
         };
-
     };
 }


### PR DESCRIPTION
prettier handles .md files with obscure extensions like vitepress has far better