### PR TITLE
Switch to BatchMode=yes instead of PasswordAuthentication=no

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   during execution.
 - Cases where there are no keys to deploy, such as having 0 keys or filtered
   keys, the "Key" step will not be planned when it previously would have.
+- Changed non-interactive SSH executed commands to use `BatchMode=yes` instead
+  of using `PasswordAuthentication=no` and `KbdInteractiveAuthentication=no`.
 
 ### Fixed
 

--- a/crates/core/src/hive/node.rs
+++ b/crates/core/src/hive/node.rs
@@ -89,8 +89,7 @@ impl Target {
             .to_string(),
         ];
 
-        options.extend(["PasswordAuthentication=no".to_string()]);
-        options.extend(["KbdInteractiveAuthentication=no".to_string()]);
+        options.extend(["BatchMode=yes".to_string()]);
 
         vector.push("-o".to_string());
         vector.extend(options.into_iter().intersperse("-o".to_string()));
@@ -351,9 +350,7 @@ mod tests {
             "-o".to_string(),
             "StrictHostKeyChecking=accept-new".to_string(),
             "-o".to_string(),
-            "PasswordAuthentication=no".to_string(),
-            "-o".to_string(),
-            "KbdInteractiveAuthentication=no".to_string(),
+            "BatchMode=yes".to_string(),
         ];
 
         assert_eq!(target.create_ssh_args(subcommand_modifiers).unwrap(), args);
@@ -372,9 +369,7 @@ mod tests {
                 "-o".to_string(),
                 "StrictHostKeyChecking=accept-new".to_string(),
                 "-o".to_string(),
-                "PasswordAuthentication=no".to_string(),
-                "-o".to_string(),
-                "KbdInteractiveAuthentication=no".to_string(),
+                "BatchMode=yes".to_string(),
             ]
         );
 
@@ -388,9 +383,7 @@ mod tests {
                 "-o".to_string(),
                 "StrictHostKeyChecking=accept-new".to_string(),
                 "-o".to_string(),
-                "PasswordAuthentication=no".to_string(),
-                "-o".to_string(),
-                "KbdInteractiveAuthentication=no".to_string(),
+                "BatchMode=yes".to_string(),
             ]
         );
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated non-interactive SSH behavior to use BatchMode for more reliable, consistent non-interactive sessions.

* **Tests**
  * Adjusted test expectations to reflect the new SSH non-interactive behavior.

* **Documentation**
  * Added changelog entry describing the SSH non-interactive behavior change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->