### PR TITLE
Revert "pass -v to ssh on --verbose"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - yyyy-mm-dd
 
-### Added
-
-- `--verbose` will pass `-v` to SSH commands.
-
 ## [v1.2.0] - 2026-03-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,7 +260,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d92b1fab272fe943881b77cc6e920d6543e5b1bfadbd5ed81c7c5a755742394"
 dependencies = [
  "clap",
- "tracing-core",
+ "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,7 @@ missing_panics_doc = "allow"
 [workspace.dependencies]
 futures-util = { version = "0.3.31", features = ["sink", "std"] }
 clap = { version = "4.5.51", features = ["derive", "string", "cargo"] }
-clap-verbosity-flag = { version = "3.0.4", features = [
-  "tracing",
-], default-features = false }
+clap-verbosity-flag = "3.0.4"
 serde = { version = "1.0.228", features = ["derive", "rc"] }
 tokio = { version = "1.48.0", features = ["full"] }
 tracing = { version = "0.1.41", features = ["release_max_level_debug"] }

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -9,7 +9,6 @@ use clap_complete::engine::ArgValueCompleter;
 use clap_num::number_range;
 use clap_verbosity_flag::InfoLevel;
 use tokio::runtime::Handle;
-use tracing::level_filters::LevelFilter;
 use wire_core::SubCommandModifiers;
 use wire_core::commands::common::get_hive_node_names;
 use wire_core::hive::node::{
@@ -333,7 +332,6 @@ impl ToSubCommandModifiers for Cli {
                 }
                 _ => wire_core::StrictHostKeyChecking::default(),
             },
-            verbose: self.verbose.tracing_level_filter() > LevelFilter::INFO,
         }
     }
 }

--- a/crates/cli/src/tracing_setup.rs
+++ b/crates/cli/src/tracing_setup.rs
@@ -10,6 +10,7 @@ use std::{
 use clap_verbosity_flag::{LogLevel, Verbosity};
 use owo_colors::{OwoColorize, Stream, Style};
 use tracing::{Level, Subscriber};
+use tracing_log::AsTrace;
 use tracing_subscriber::{
     Layer,
     field::{RecordFields, VisitFmt},
@@ -251,7 +252,7 @@ async fn status_tick_worker() {
 /// Set up logging for the application
 /// Uses `WireFieldFormat` if -v was never passed
 pub fn setup_logging<L: LogLevel>(verbosity: &Verbosity<L>, show_progress: bool) {
-    let filter = verbosity.tracing_level_filter();
+    let filter = verbosity.log_level_filter().as_trace();
     let registry = tracing_subscriber::registry();
 
     STATUS.lock().show_progress(show_progress);

--- a/crates/core/src/hive/node.rs
+++ b/crates/core/src/hive/node.rs
@@ -91,10 +91,6 @@ impl Target {
 
         options.extend(["BatchMode=yes".to_string()]);
 
-        if modifiers.verbose {
-            vector.push("-v".to_string());
-        }
-
         vector.push("-o".to_string());
         vector.extend(options.into_iter().intersperse("-o".to_string()));
 
@@ -330,78 +326,77 @@ mod tests {
     use super::*;
     use std::{assert_matches::assert_matches, env};
 
-    fn setup_ssh_opts_test() -> (Target, String) {
+    #[test]
+    fn test_ssh_opts() {
         let target = Target::from_host("hello-world");
+        let subcommand_modifiers = SubCommandModifiers {
+            non_interactive: false,
+            ..Default::default()
+        };
         let tmp = format!(
             "/tmp/{}",
             rand::distr::SampleString::sample_string(&Alphabetic, &mut rand::rng(), 10)
         );
+
         std::fs::create_dir(&tmp).unwrap();
-        unsafe { env::set_var("XDG_RUNTIME_DIR", &tmp) };
-        (target, tmp)
-    }
 
-    #[test]
-    fn test_ssh_opts_verbose() {
-        let (target, _tmp) = setup_ssh_opts_test();
+        unsafe { env::set_var("XDG_RUNTIME_DIR", &tmp) }
 
-        let args = target
-            .create_ssh_args(SubCommandModifiers {
-                verbose: true,
-                ..Default::default()
-            })
-            .unwrap();
-
-        assert!(
-            args.contains(&"-v".to_string()),
-            "Verbose flag should add -v to SSH args"
-        );
-
-        let expected = vec![
+        let args = [
             "-l".to_string(),
             target.user.to_string(),
             "-p".to_string(),
             target.port.to_string(),
-            "-v".to_string(),
             "-o".to_string(),
             "StrictHostKeyChecking=accept-new".to_string(),
             "-o".to_string(),
             "BatchMode=yes".to_string(),
         ];
-        assert_eq!(args, expected);
-    }
 
-    #[test]
-    fn test_ssh_opts_non_interactive() {
-        let (target, _tmp) = setup_ssh_opts_test();
-
-        let default_args = target
-            .create_ssh_args(SubCommandModifiers::default())
-            .unwrap();
-
-        let non_interactive_args = target
-            .create_ssh_args(SubCommandModifiers {
-                non_interactive: true,
-                ..Default::default()
-            })
-            .unwrap();
+        assert_eq!(target.create_ssh_args(subcommand_modifiers).unwrap(), args);
+        assert_eq!(
+            target.create_ssh_opts(subcommand_modifiers).unwrap(),
+            args.join(" ")
+        );
 
         assert_eq!(
-            default_args, non_interactive_args,
-            "non_interactive flag should not affect SSH args"
+            target.create_ssh_args(subcommand_modifiers).unwrap(),
+            [
+                "-l".to_string(),
+                target.user.to_string(),
+                "-p".to_string(),
+                target.port.to_string(),
+                "-o".to_string(),
+                "StrictHostKeyChecking=accept-new".to_string(),
+                "-o".to_string(),
+                "BatchMode=yes".to_string(),
+            ]
         );
 
-        let expected = vec![
-            "-l".to_string(),
-            target.user.to_string(),
-            "-p".to_string(),
-            target.port.to_string(),
-            "-o".to_string(),
-            "StrictHostKeyChecking=accept-new".to_string(),
-            "-o".to_string(),
-            "BatchMode=yes".to_string(),
-        ];
-        assert_eq!(default_args, expected);
+        assert_eq!(
+            target.create_ssh_args(subcommand_modifiers).unwrap(),
+            [
+                "-l".to_string(),
+                target.user.to_string(),
+                "-p".to_string(),
+                target.port.to_string(),
+                "-o".to_string(),
+                "StrictHostKeyChecking=accept-new".to_string(),
+                "-o".to_string(),
+                "BatchMode=yes".to_string(),
+            ]
+        );
+
+        // forced non interactive is the same as --non-interactive
+        assert_eq!(
+            target.create_ssh_args(subcommand_modifiers).unwrap(),
+            target
+                .create_ssh_args(SubCommandModifiers {
+                    non_interactive: true,
+                    ..Default::default()
+                })
+                .unwrap()
+        );
     }
 
     #[test]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -43,7 +43,6 @@ pub struct SubCommandModifiers {
     pub show_trace: bool,
     pub non_interactive: bool,
     pub ssh_accept_host: StrictHostKeyChecking,
-    pub verbose: bool,
 }
 
 impl Default for SubCommandModifiers {
@@ -52,7 +51,6 @@ impl Default for SubCommandModifiers {
             show_trace: false,
             non_interactive: !std::io::stdin().is_terminal(),
             ssh_accept_host: StrictHostKeyChecking::default(),
-            verbose: false,
         }
     }
 }


### PR DESCRIPTION
Reverts forallsys/wire#407

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed `--verbose` command-line flag and associated verbose SSH mode support
  
* **Updates**
  * Updated logging configuration implementation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->