### PR TITLE
add sops example

### DIFF
--- a/doc/guides/keys.md
+++ b/doc/guides/keys.md
@@ -18,7 +18,7 @@ The `source` of your key can be a literal string (unencrypted), a path
 work well with wire keys include:
 
 - GPG
-- [sops](https://github.com/getsops/sops) ([Example](#with-sops))
+- [sops](https://github.com/getsops/sops) ([Example](#encrypting-with-sops))
 - [Age](https://github.com/FiloSottile/age)
 - Anything that non-interactively decrypts to `stdout`.
 

--- a/doc/guides/keys.md
+++ b/doc/guides/keys.md
@@ -18,6 +18,7 @@ The `source` of your key can be a literal string (unencrypted), a path
 work well with wire keys include:
 
 - GPG
+- [sops](https://github.com/getsops/sops) ([Example](#with-sops))
 - [Age](https://github.com/FiloSottile/age)
 - Anything that non-interactively decrypts to `stdout`.
 
@@ -185,6 +186,21 @@ in wire.makeHive {
 ```
 
 ## Further Examples
+
+### With Sops
+
+With some sops file:
+
+```yaml:line-numbers [secret.yaml]
+hive:
+    some_secret: XXXXXXXXXXXXXXXXXXXXXXX
+something:
+    another_secret: XXXXXXXXXXXXXXXXXXXXXXX
+```
+
+You can easily create a function to grab values out of your encrypted sops file:
+
+<<< @/snippets/guides/sops-example.nix [hive.nix]
 
 ### Using Keys With Services
 

--- a/doc/guides/keys.md
+++ b/doc/guides/keys.md
@@ -95,6 +95,21 @@ in wire.makeHive {
 Hello World!
 ```
 
+### Encrypting with Sops
+
+With some sops file:
+
+```yaml:line-numbers [secret.yaml]
+hive:
+    some_secret: XXXXXXXXXXXXXXXXXXXXXXX
+something:
+    another_secret: XXXXXXXXXXXXXXXXXXXXXXX
+```
+
+You can easily create a function to grab values out of your encrypted sops file:
+
+<<< @/snippets/guides/sops-example.nix [hive.nix]
+
 ### Encrypting with KeepassXC
 
 A simple example of extracting a KeepassXC attachment into a wire key.
@@ -186,21 +201,6 @@ in wire.makeHive {
 ```
 
 ## Further Examples
-
-### With Sops
-
-With some sops file:
-
-```yaml:line-numbers [secret.yaml]
-hive:
-    some_secret: XXXXXXXXXXXXXXXXXXXXXXX
-something:
-    another_secret: XXXXXXXXXXXXXXXXXXXXXXX
-```
-
-You can easily create a function to grab values out of your encrypted sops file:
-
-<<< @/snippets/guides/sops-example.nix [hive.nix]
 
 ### Using Keys With Services
 

--- a/doc/snippets/guides/sops-example.nix
+++ b/doc/snippets/guides/sops-example.nix
@@ -11,7 +11,7 @@ in
         "-d"
         "--extract"
         (lib.concatMapStrings (segment: ''["${segment}"]'') key)
-        "${../secrets.yaml}"
+        "${./secrets.yaml}"
       ];
     in {
       deployment.key = {

--- a/doc/snippets/guides/sops-example.nix
+++ b/doc/snippets/guides/sops-example.nix
@@ -1,0 +1,33 @@
+let
+  sources = import ./npins;
+  wire = import sources.wire;
+in
+  wire.makeHive {
+    meta.nixpkgs = import sources.nixpkgs {};
+
+    node-1 = {lib, ...}: let
+      mkSops = key: [
+        "sops"
+        "-d"
+        "--extract"
+        (lib.concatMapStrings (segment: ''["${segment}"]'') key)
+        "${../secrets.yaml}"
+      ];
+    in {
+      deployment.key = {
+        "some_secret.txt" = {
+          source = mkSops [
+            "hive"
+            "some_secret"
+          ];
+        };
+
+        "another_secret.txt" = {
+          source = mkSops [
+            "something"
+            "another_secret"
+          ];
+        };
+      };
+    };
+  }


### PR DESCRIPTION
closes #386 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added SOPS as a supported non-interactive key source alongside GPG and Age.
  * Added an "Encrypting with Sops" subsection with a sample encrypted YAML secrets structure and guidance for extracting values.
  * Included a reusable example showing how to decrypt a SOPS file and extract multiple secret outputs for deployment use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->