### PR TITLE
switch to snix for log parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -864,12 +864,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
-name = "gjson"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43503cc176394dd30a6525f5f36e838339b8b5619be33ed9a7783841580a97b6"
-
-[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3209,7 +3203,6 @@ dependencies = [
  "enum_dispatch",
  "futures",
  "gethostname",
- "gjson",
  "im",
  "itertools",
  "miette",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -35,7 +35,6 @@ nix-compat = { workspace = true }
 strip-ansi-escapes = "0.2.1"
 aho-corasick = "1.1.4"
 num_enum = "0.7.5"
-gjson = "0.8.1"
 owo-colors = { workspace = true }
 termion = "4.0.6"
 sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite"] }

--- a/crates/core/src/commands/mod.rs
+++ b/crates/core/src/commands/mod.rs
@@ -7,15 +7,12 @@ use crate::{
 };
 use std::{
     collections::HashMap,
-    str::from_utf8,
     sync::{Arc, LazyLock},
 };
 
 use aho_corasick::AhoCorasick;
-use gjson::Value;
 use itertools::Itertools;
-use nix_compat::log::{AT_NIX_PREFIX, VerbosityLevel};
-use num_enum::TryFromPrimitive;
+use nix_compat::log::{AT_NIX_PREFIX, LogMessage, VerbosityLevel};
 use tracing::{debug, error, info, trace, warn};
 
 use crate::{
@@ -156,47 +153,6 @@ impl WireCommandChip for Either<InteractiveChildChip, NonInteractiveChildChip> {
     }
 }
 
-fn trace_gjson_str<'a>(log: &'a Value<'a>, msg: &'a str) -> Option<String> {
-    if msg.is_empty() {
-        return None;
-    }
-
-    let level = log.get("level");
-
-    if !level.exists() {
-        return None;
-    }
-
-    let level = match VerbosityLevel::try_from_primitive(level.u64()) {
-        Ok(level) => level,
-        Err(err) => {
-            error!("nix log `level` did not match to a VerbosityLevel: {err:?}");
-            return None;
-        }
-    };
-
-    let msg = strip_ansi_escapes::strip_str(msg);
-
-    match level {
-        VerbosityLevel::Info => info!("{msg}"),
-        VerbosityLevel::Warn | VerbosityLevel::Notice => warn!("{msg}"),
-        VerbosityLevel::Error => error!("{msg}"),
-        VerbosityLevel::Debug => debug!("{msg}"),
-        VerbosityLevel::Vomit | VerbosityLevel::Talkative | VerbosityLevel::Chatty => {
-            trace!("{msg}");
-        }
-    }
-
-    if matches!(
-        level,
-        VerbosityLevel::Error | VerbosityLevel::Warn | VerbosityLevel::Notice
-    ) {
-        return Some(msg);
-    }
-
-    None
-}
-
 impl ChildOutputMode {
     /// this function is by far the biggest hotspot in the whole tree
     /// Returns a string if this log is notable to be stored as an error message
@@ -221,23 +177,33 @@ impl ChildOutputMode {
             }
         };
 
-        let Ok(str) = from_utf8(slice) else {
-            error!("nix log was not valid utf8!");
+        let Ok(log_message) = serde_json::from_slice::<LogMessage>(slice) else {
+            // failed to parse, print the string regardless as a backup
+            warn!("{}", String::from_utf8_lossy(slice));
             return None;
         };
 
-        let log = gjson::parse(str);
+        let (msg, level) = match log_message {
+            LogMessage::Start { text, level, .. } => (text, level),
+            LogMessage::Msg { msg, level, .. } => (msg, level),
+            _ => return None
+        };
 
-        let text = log.get("text");
-
-        if text.exists() {
-            return trace_gjson_str(&log, text.str());
+        match level {
+            VerbosityLevel::Info => info!("{msg}"),
+            VerbosityLevel::Warn | VerbosityLevel::Notice => warn!("{msg}"),
+            VerbosityLevel::Error => error!("{msg}"),
+            VerbosityLevel::Debug => debug!("{msg}"),
+            VerbosityLevel::Vomit | VerbosityLevel::Talkative | VerbosityLevel::Chatty => {
+                trace!("{msg}");
+            }
         }
 
-        let text = log.get("msg");
-
-        if text.exists() {
-            return trace_gjson_str(&log, text.str());
+        if matches!(
+            level,
+            VerbosityLevel::Error | VerbosityLevel::Warn | VerbosityLevel::Notice
+        ) {
+            return Some(msg.to_string());
         }
 
         None

--- a/crates/core/src/commands/mod.rs
+++ b/crates/core/src/commands/mod.rs
@@ -186,7 +186,7 @@ impl ChildOutputMode {
         let (msg, level) = match log_message {
             LogMessage::Start { text, level, .. } => (text, level),
             LogMessage::Msg { msg, level, .. } => (msg, level),
-            _ => return None
+            _ => return None,
         };
 
         match level {

--- a/crates/core/src/commands/mod.rs
+++ b/crates/core/src/commands/mod.rs
@@ -168,7 +168,7 @@ impl ChildOutputMode {
                 let position = AHO_CORASICK.find(&line).map(|x| &mut line[x.end()..]);
 
                 if let Some(json_buf) = position {
-                    (json_buf, task_name)
+                    json_buf
                 } else {
                     // usually happens when ssh is outputting something
                     warn!("{}", String::from_utf8_lossy(line));

--- a/crates/core/src/commands/mod.rs
+++ b/crates/core/src/commands/mod.rs
@@ -168,7 +168,7 @@ impl ChildOutputMode {
                 let position = AHO_CORASICK.find(&line).map(|x| &mut line[x.end()..]);
 
                 if let Some(json_buf) = position {
-                    json_buf
+                    (json_buf, task_name)
                 } else {
                     // usually happens when ssh is outputting something
                     warn!("{}", String::from_utf8_lossy(line));
@@ -189,6 +189,12 @@ impl ChildOutputMode {
             _ => return None,
         };
 
+        if msg.is_empty() {
+            return None;
+        }
+
+        let msg = strip_ansi_escapes::strip_str(msg);
+
         match level {
             VerbosityLevel::Info => info!("{msg}"),
             VerbosityLevel::Warn | VerbosityLevel::Notice => warn!("{msg}"),
@@ -203,7 +209,7 @@ impl ChildOutputMode {
             level,
             VerbosityLevel::Error | VerbosityLevel::Warn | VerbosityLevel::Notice
         ) {
-            return Some(msg.to_string());
+            return Some(msg);
         }
 
         None


### PR DESCRIPTION
Closes #404

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reduced internal dependency footprint and simplified JSON log parsing.

* **Bug Fixes**
  * More resilient handling of malformed or non-UTF-8 log output with safer fallbacks and clearer diagnostics.
  * Log display now surfaces only higher-severity messages and respects verbosity settings, with ANSI control codes removed for cleaner output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->