### PR TITLE
let sudo quit on ctrl+c

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Status bar is cleaned every time after execution is completed.
+- Sudo prompt's being un-quittable, even with ctrl+c.
 
 ## [v1.2.0] - 2026-03-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Status bar is cleaned every time after execution is completed.
-- Sudo prompt's being un-quittable, even with ctrl+c.
+- Sudo prompt could not be exited with Ctrl+C.
 
 ## [v1.2.0] - 2026-03-18
 

--- a/crates/core/src/commands/pty/mod.rs
+++ b/crates/core/src/commands/pty/mod.rs
@@ -301,9 +301,6 @@ fn setup_master(pty_pair: &PtyPair) -> Result<(), HiveLibError> {
         termios.local_flags &= !LocalFlags::ECHO;
         // Key agent does not work well without canonical mode
         termios.local_flags &= !LocalFlags::ICANON;
-        // Actually quit
-        termios.local_flags &= !LocalFlags::ISIG;
-
         tcsetattr(fd, SetArg::TCSANOW, &termios)
             .map_err(|x| HiveLibError::CommandError(CommandError::TermAttrs(x)))?;
     }
@@ -417,7 +414,7 @@ impl StdinTermiosAttrGuard {
         let mut termios = tcgetattr(stdin_fd).map_err(CommandError::TermAttrs)?;
         let original_termios = termios.clone();
 
-        termios.local_flags &= !(LocalFlags::ECHO | LocalFlags::ICANON);
+        termios.local_flags &= !(LocalFlags::ECHO | LocalFlags::ICANON | LocalFlags::ISIG);
         tcsetattr(stdin_fd, SetArg::TCSANOW, &termios).map_err(CommandError::TermAttrs)?;
 
         Ok(StdinTermiosAttrGuard(original_termios))


### PR DESCRIPTION
#393 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Documented and fixed an issue where the sudo prompt could not be exited using Ctrl+C.

* **Changes**
  * Updated terminal signal handling so signals (like interrupts) behave differently during command execution, improving expected interrupt behavior for interactive prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->