### PR TITLE
surround drv in qoutes in build phase command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Some host shells, like fish, would break the `build` phase command. The
+  problematic string is now surrounded in quotes.
 - Status bar is cleaned every time after execution is completed.
 - Fixed garnix docs links in documentation.
 

--- a/crates/core/src/hive/steps/build.rs
+++ b/crates/core/src/hive/steps/build.rs
@@ -8,8 +8,7 @@ use tracing::{info, instrument};
 use crate::{
     HiveLibError,
     commands::{
-        CommandArguments, Either, WireCommandChip, builder::CommandStringBuilder,
-        run_command_with_env,
+        CommandArguments, Either, WireCommandChip, builder::CommandStringBuilder, run_command
     },
     hive::node::{Context, ExecuteStep, SharedTarget},
 };
@@ -40,15 +39,14 @@ impl ExecuteStep for Build {
             "--no-link",
             "--print-out-paths",
         ]);
-        command_string.arg(top_level.to_string());
+        command_string.arg(format!("\"{top_level}\""));
 
-        let status = run_command_with_env(
+        let status = run_command(
             &CommandArguments::new(command_string, ctx.modifiers)
                 // build remotely if asked for AND we arent applying locally
                 .execute_on_remote(self.target.clone())
                 .mode(crate::commands::ChildOutputMode::Nix)
                 .log_stdout(),
-            std::collections::HashMap::new(),
         )
         .await?
         .wait_till_success()

--- a/crates/core/src/hive/steps/build.rs
+++ b/crates/core/src/hive/steps/build.rs
@@ -8,7 +8,7 @@ use tracing::{info, instrument};
 use crate::{
     HiveLibError,
     commands::{
-        CommandArguments, Either, WireCommandChip, builder::CommandStringBuilder, run_command
+        CommandArguments, Either, WireCommandChip, builder::CommandStringBuilder, run_command,
     },
     hive::node::{Context, ExecuteStep, SharedTarget},
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed build command compatibility with certain shells (notably fish) by ensuring the top-level argument is properly quoted, preventing parsing failures during the build phase.
  * Improved how the build command is invoked to avoid passing an empty environment mapping, increasing reliability across host shells and environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->