### PR TITLE
add --print-build-logs arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - yyyy-mm-dd
 
+### Added
+
+- `--print-build-logs` / `-L` argument.
+
 ### Changed
 
 - The pre-activation key stage is now scheduled after the evaluation stage. The

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -173,6 +173,9 @@ pub struct CommonVerbArgs {
 
     #[arg(short, long, default_value_t = 10, value_parser=more_than_zero)]
     pub parallel: usize,
+
+    #[arg(short = 'L', long, default_value_t = false)]
+    pub print_build_logs: bool,
 }
 
 #[allow(clippy::struct_excessive_bools)]
@@ -335,6 +338,11 @@ impl ToSubCommandModifiers for Cli {
                     wire_core::StrictHostKeyChecking::No
                 }
                 _ => wire_core::StrictHostKeyChecking::default(),
+            },
+            print_build_logs: match &self.command {
+                Commands::Apply(args) => args.common.print_build_logs,
+                Commands::Build(args) => args.common.print_build_logs,
+                Commands::Inspect { .. } => false,
             },
             ssh_verbosity: match &self.command {
                 Commands::Apply(args) => args.ssh_verbose.into(),

--- a/crates/core/src/commands/common.rs
+++ b/crates/core/src/commands/common.rs
@@ -148,6 +148,7 @@ pub async fn evaluate_hive_attribute(
         "--json",
     ]);
     command_string.opt_arg(modifiers.show_trace, "--show-trace");
+    command_string.opt_arg(modifiers.print_build_logs, "--print-build-logs");
     command_string.arg(&attribute);
 
     let child = run_command(

--- a/crates/core/src/hive/steps/build.rs
+++ b/crates/core/src/hive/steps/build.rs
@@ -36,10 +36,10 @@ impl ExecuteStep for Build {
             "--extra-experimental-features",
             "nix-command",
             "build",
-            "--print-build-logs",
             "--no-link",
             "--print-out-paths",
         ]);
+        command_string.opt_arg(ctx.modifiers.print_build_logs, "--print-build-logs");
         command_string.arg(top_level.to_string());
 
         let status = run_command_with_env(

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -45,6 +45,7 @@ pub struct SubCommandModifiers {
     pub non_interactive: bool,
     pub ssh_accept_host: StrictHostKeyChecking,
     pub ssh_verbosity: usize,
+    pub print_build_logs: bool,
 }
 
 impl Default for SubCommandModifiers {
@@ -54,6 +55,7 @@ impl Default for SubCommandModifiers {
             non_interactive: !std::io::stdin().is_terminal(),
             ssh_accept_host: StrictHostKeyChecking::default(),
             ssh_verbosity: 0,
+            print_build_logs: false,
         }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--print-build-logs` / `-L` command-line flag for `wire apply` and `wire build` commands to control build log output (disabled by default).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/forallsys/wire/pull/474?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->