### PR TITLE
force `bash`, instead of user's unsupported shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   problematic string is now surrounded in quotes.
 - Status bar is cleaned every time after execution is completed.
 - Fixed garnix docs links in documentation.
+- Forces `bash` instead of remote user's potentially unsupported shell. This bug
+  was causing strange and hard to diagnose issues.
 
 ## [v1.2.0] - 2026-03-18
 

--- a/crates/core/src/commands/noninteractive.rs
+++ b/crates/core/src/commands/noninteractive.rs
@@ -39,7 +39,7 @@ pub(crate) async fn non_interactive_command_with_env<S: AsRef<str>>(
     let mut command = if let Some(ref target) = arguments.target {
         create_sync_ssh_command(target, arguments.modifiers).await?
     } else {
-        let mut command = Command::new("sh");
+        let mut command = Command::new("bash");
 
         command.arg("-c");
 

--- a/crates/core/src/commands/pty/mod.rs
+++ b/crates/core/src/commands/pty/mod.rs
@@ -323,7 +323,7 @@ async fn build_command<S: AsRef<str>>(
 
         command
     } else {
-        let mut command = portable_pty::CommandBuilder::new("sh");
+        let mut command = portable_pty::CommandBuilder::new("bash");
 
         command.arg("-c");
 
@@ -331,9 +331,9 @@ async fn build_command<S: AsRef<str>>(
     };
 
     if arguments.is_elevated() {
-        command.arg(format!("sudo -u root -- sh -c '{command_string}'"));
+        command.arg(format!("sudo -u root -- bash -c '{command_string}'"));
     } else {
-        command.arg(command_string);
+        command.arg(format!("bash -c '{command_string}'"));
     }
 
     Ok(command)


### PR DESCRIPTION
- [ ] Document that bash is a requirement of the remote machine

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Remote command execution now consistently uses bash shell, resolving compatibility issues that could occur when the remote user's default shell was unsupported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->