### PR TITLE
Revert "surround drv in qoutes in build phase command"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Some host shells, like fish, would break the `build` phase command. The
-  problematic string is now surrounded in quotes.
 - Status bar is cleaned every time after execution is completed.
 - Fixed garnix docs links in documentation.
 

--- a/crates/core/src/hive/steps/build.rs
+++ b/crates/core/src/hive/steps/build.rs
@@ -8,7 +8,8 @@ use tracing::{info, instrument};
 use crate::{
     HiveLibError,
     commands::{
-        CommandArguments, Either, WireCommandChip, builder::CommandStringBuilder, run_command,
+        CommandArguments, Either, WireCommandChip, builder::CommandStringBuilder,
+        run_command_with_env,
     },
     hive::node::{Context, ExecuteStep, SharedTarget},
 };
@@ -39,14 +40,15 @@ impl ExecuteStep for Build {
             "--no-link",
             "--print-out-paths",
         ]);
-        command_string.arg(format!("\"{top_level}\""));
+        command_string.arg(top_level.to_string());
 
-        let status = run_command(
+        let status = run_command_with_env(
             &CommandArguments::new(command_string, ctx.modifiers)
                 // build remotely if asked for AND we arent applying locally
                 .execute_on_remote(self.target.clone())
                 .mode(crate::commands::ChildOutputMode::Nix)
                 .log_stdout(),
+            std::collections::HashMap::new(),
         )
         .await?
         .wait_till_success()


### PR DESCRIPTION
Reverts forallsys/wire#470

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined how build commands are executed and environment variables are configured to enhance shell compatibility.

* **Documentation**
  * Updated changelog to reflect recent build process improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->