### PR TITLE
encode commands in base64 to reduce quote bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cargo dependency updates.
 - Switched (back) to the https://snix.dev/ `nix_compat` crate for internal nix
   json log parsing.
+- Executed commands are encoded in base64 to harden the strings and help them
+  survive cross-shell parsing errors.
 
 ### Fixed
 
 - Status bar is cleaned every time after execution is completed.
+- `deployment.privilegeEscalationCommand` not being consistently applied.
 - Fixed garnix docs links in documentation.
 - Forces `bash` instead of remote user's potentially unsupported shell. This bug
   was causing strange and hard to diagnose issues.

--- a/crates/core/src/commands/noninteractive.rs
+++ b/crates/core/src/commands/noninteractive.rs
@@ -13,6 +13,7 @@ use crate::{
     errors::{CommandError, HiveLibError},
     hive::node::SharedTarget,
 };
+use base64::{Engine, engine::general_purpose::STANDARD};
 use itertools::Itertools;
 use tokio::{
     io::{AsyncWriteExt, BufReader},
@@ -55,10 +56,12 @@ pub(crate) async fn non_interactive_command_with_env<S: AsRef<str>>(
         }
     );
 
+    let encoded = STANDARD.encode(&command_string);
+
     let command_string = if let Some(escalation_command) = &arguments.privilege_escalation_command {
-        format!("{escalation_command} sh -c '{command_string}'")
+        format!("{escalation_command} sh -c 'echo {encoded} | base64 -d | bash'")
     } else {
-        command_string
+        format!("echo {encoded} | base64 -d | bash")
     };
 
     debug!("{command_string}");

--- a/crates/core/src/commands/noninteractive.rs
+++ b/crates/core/src/commands/noninteractive.rs
@@ -66,12 +66,10 @@ pub(crate) async fn non_interactive_command_with_env<S: AsRef<str>>(
         } else {
             format!("{escalation_command} sh -c 'echo {encoded} | base64 -d | bash'")
         }
+    } else if arguments.keep_stdin_open {
+        command_string
     } else {
-        if arguments.keep_stdin_open {
-            command_string
-        } else {
-            format!("echo {encoded} | base64 -d | bash")
-        }
+        format!("echo {encoded} | base64 -d | bash")
     };
 
     debug!("{command_string}");

--- a/crates/core/src/commands/noninteractive.rs
+++ b/crates/core/src/commands/noninteractive.rs
@@ -58,10 +58,20 @@ pub(crate) async fn non_interactive_command_with_env<S: AsRef<str>>(
 
     let encoded = STANDARD.encode(&command_string);
 
+    // keep_stdin_open requires that bash not have its stdin messed up by
+    // base64, so a special case is created specifically for that.
     let command_string = if let Some(escalation_command) = &arguments.privilege_escalation_command {
-        format!("{escalation_command} sh -c 'echo {encoded} | base64 -d | bash'")
+        if arguments.keep_stdin_open {
+            format!("{escalation_command} sh -c '{command_string}'")
+        } else {
+            format!("{escalation_command} sh -c 'echo {encoded} | base64 -d | bash'")
+        }
     } else {
-        format!("echo {encoded} | base64 -d | bash")
+        if arguments.keep_stdin_open {
+            command_string
+        } else {
+            format!("echo {encoded} | base64 -d | bash")
+        }
     };
 
     debug!("{command_string}");

--- a/crates/core/src/commands/pty/mod.rs
+++ b/crates/core/src/commands/pty/mod.rs
@@ -342,12 +342,10 @@ async fn build_command<S: AsRef<str>>(
                 "{escalation_command} sh -c 'echo {encoded} | base64 -d | bash'"
             ));
         }
+    } else if arguments.keep_stdin_open {
+        command.arg(command_string);
     } else {
-        if arguments.keep_stdin_open {
-            command.arg(command_string);
-        } else {
-            command.arg(format!("echo {encoded} | base64 -d | bash"));
-        }
+        command.arg(format!("echo {encoded} | base64 -d | bash"));
     }
 
     Ok(command)

--- a/crates/core/src/commands/pty/mod.rs
+++ b/crates/core/src/commands/pty/mod.rs
@@ -5,6 +5,7 @@ use crate::commands::pty::output::{WatchStdoutArguments, handle_pty_stdout};
 use crate::hive::node::SharedTarget;
 use crate::status::{UI_SENDER, UiMessage};
 use aho_corasick::PatternID;
+use base64::{Engine, engine::general_purpose::STANDARD};
 use itertools::Itertools;
 use nix::sys::termios::{LocalFlags, SetArg, Termios, tcgetattr, tcsetattr};
 use nix::unistd::pipe;
@@ -244,9 +245,9 @@ pub(crate) async fn interactive_command_with_env<S: AsRef<str>>(
 async fn print_authenticate_warning<S: AsRef<str>>(
     arguments: &CommandArguments<S>,
 ) -> Result<(), HiveLibError> {
-    if !arguments.is_elevated() {
+    let Some(ref privilege_escalation_command) = arguments.privilege_escalation_command else {
         return Ok(());
-    }
+    };
 
     let target_display = if let Some(ref target) = arguments.target {
         let target = target.0.read().await;
@@ -264,7 +265,8 @@ async fn print_authenticate_warning<S: AsRef<str>>(
     if let Some(tx) = UI_SENDER.get() {
         let _ = tx.send(UiMessage::LogLine(
             format!(
-                "{target_display} | Authenticate for \"sudo {}\":\n",
+                "{target_display} | Authenticate {} \"{}\":\n",
+                privilege_escalation_command,
                 arguments.command_string.as_ref()
             )
             .into_bytes(),
@@ -330,10 +332,14 @@ async fn build_command<S: AsRef<str>>(
         command
     };
 
-    if arguments.is_elevated() {
-        command.arg(format!("sudo -u root -- bash -c '{command_string}'"));
+    let encoded = STANDARD.encode(command_string);
+
+    if let Some(escalation_command) = &arguments.privilege_escalation_command {
+        command.arg(format!(
+            "{escalation_command} sh -c 'echo {encoded} | base64 -d | bash'"
+        ));
     } else {
-        command.arg(format!("bash -c '{command_string}'"));
+        command.arg(format!("echo {encoded} | base64 -d | bash"));
     }
 
     Ok(command)

--- a/crates/core/src/commands/pty/mod.rs
+++ b/crates/core/src/commands/pty/mod.rs
@@ -335,11 +335,19 @@ async fn build_command<S: AsRef<str>>(
     let encoded = STANDARD.encode(command_string);
 
     if let Some(escalation_command) = &arguments.privilege_escalation_command {
-        command.arg(format!(
-            "{escalation_command} sh -c 'echo {encoded} | base64 -d | bash'"
-        ));
+        if arguments.keep_stdin_open {
+            command.arg(format!("{escalation_command} sh -c '{command_string}'"));
+        } else {
+            command.arg(format!(
+                "{escalation_command} sh -c 'echo {encoded} | base64 -d | bash'"
+            ));
+        }
     } else {
-        command.arg(format!("echo {encoded} | base64 -d | bash"));
+        if arguments.keep_stdin_open {
+            command.arg(command_string);
+        } else {
+            command.arg(format!("echo {encoded} | base64 -d | bash"));
+        }
     }
 
     Ok(command)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Command execution is now encoded to improve reliability across diverse shell environments.
  * Privilege escalation is applied consistently when configured, fixing cases where it was previously ignored.
  * Authentication/notification messages now reflect whether an escalation command is configured.

* **Documentation**
  * Changelog updated to document these changes and clarify release notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->