### PR TITLE
fix escalation_command not used for interactive command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cargo dependency updates.
 - Switched (back) to the https://snix.dev/ `nix_compat` crate for internal nix
   json log parsing.
+- `deployment.privilegeEscalationCommand` not being consistently applied.
 
 ### Fixed
 

--- a/crates/core/src/commands/pty/mod.rs
+++ b/crates/core/src/commands/pty/mod.rs
@@ -244,9 +244,9 @@ pub(crate) async fn interactive_command_with_env<S: AsRef<str>>(
 async fn print_authenticate_warning<S: AsRef<str>>(
     arguments: &CommandArguments<S>,
 ) -> Result<(), HiveLibError> {
-    if !arguments.is_elevated() {
+    let Some(ref escalation_command) = arguments.privilege_escalation_command else {
         return Ok(());
-    }
+    };
 
     let target_display = if let Some(ref target) = arguments.target {
         let target = target.0.read().await;
@@ -264,7 +264,7 @@ async fn print_authenticate_warning<S: AsRef<str>>(
     if let Some(tx) = UI_SENDER.get() {
         let _ = tx.send(UiMessage::LogLine(
             format!(
-                "{target_display} | Authenticate for \"sudo {}\":\n",
+                "{target_display} | Authenticate for \"{escalation_command} {}\":\n",
                 arguments.command_string.as_ref()
             )
             .into_bytes(),
@@ -330,8 +330,8 @@ async fn build_command<S: AsRef<str>>(
         command
     };
 
-    if arguments.is_elevated() {
-        command.arg(format!("sudo -u root -- bash -c '{command_string}'"));
+    if let Some(ref escalation_command) = arguments.privilege_escalation_command {
+        command.arg(format!("{escalation_command} bash -c '{command_string}'"));
     } else {
         command.arg(format!("bash -c '{command_string}'"));
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Privilege escalation command is now consistently applied across authentication and command execution flows.
  * System now uses the configured privilege escalation method instead of relying on hardcoded defaults.
  * Authentication warnings and command invocation now properly reflect the actual escalation configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->