### PR TITLE
use OpenOptions instead of manually setting permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed garnix docs links in documentation.
 - Forces `bash` instead of remote user's potentially unsupported shell. This bug
   was causing strange and hard to diagnose issues.
+- Fixed a possible time-of-check to time-of-use bug while setting key permissions.
 
 ## [v1.2.0] - 2026-03-18
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ tracing-subscriber = "0.3.20"
 im = { version = "15.1.0", features = ["serde"] }
 anyhow = "1.0.100"
 prost = "0.14.1"
-nix = { version = "0.31.0", features = ["user", "poll", "term"] }
+nix = { version = "0.31.0", features = ["user", "poll", "term", "fs"] }
 miette = { version = "7.6.0", features = ["fancy"] }
 thiserror = "2.0.17"
 sha2 = "0.11.0"

--- a/crates/key_agent/src/main.rs
+++ b/crates/key_agent/src/main.rs
@@ -13,7 +13,6 @@ use prost::Message;
 use prost::bytes::Bytes;
 use sha2::{Digest, Sha256};
 use std::os::fd::AsFd;
-use std::os::fd::AsRawFd;
 use std::path::{Path, PathBuf};
 use tokio::fs::OpenOptions;
 use tokio::io::AsyncWriteExt;
@@ -97,7 +96,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
                         0.into()
                     },
-                    |user| user.uid.into(),
+                    |user| user.uid,
                 ),
         );
         let group = Some(

--- a/crates/key_agent/src/main.rs
+++ b/crates/key_agent/src/main.rs
@@ -2,17 +2,20 @@
 // Copyright 2024-2025 wire Contributors
 
 #![deny(clippy::pedantic)]
+use anyhow::Context;
 use base64::Engine;
 use base64::prelude::BASE64_STANDARD;
 use futures_util::stream::StreamExt;
+use nix::sys::stat::fchmod;
+use nix::unistd::fchown;
 use nix::unistd::{Group, User};
 use prost::Message;
 use prost::bytes::Bytes;
 use sha2::{Digest, Sha256};
-use std::os::unix::fs::PermissionsExt;
-use std::os::unix::fs::chown;
+use std::os::fd::AsFd;
+use std::os::fd::AsRawFd;
 use std::path::{Path, PathBuf};
-use tokio::fs::File;
+use tokio::fs::OpenOptions;
 use tokio::io::AsyncWriteExt;
 use tokio_util::codec::{FramedRead, LengthDelimitedCodec};
 use wire_key_agent::keys::KeySpec;
@@ -63,26 +66,58 @@ async fn main() -> Result<(), anyhow::Error> {
         }
 
         let path = PathBuf::from(&spec.destination);
-        create_path(&path)?;
+        create_path(&path).context("creating directory for key")?;
 
-        let mut file = File::create(path).await?;
-        let mut permissions = file.metadata().await?.permissions();
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            // only applies if the file is created
+            .mode(spec.unix_mode)
+            .custom_flags(nix::libc::O_NOFOLLOW)
+            .open(&path)
+            .await
+            .context("opening file")?;
 
-        permissions.set_mode(spec.unix_mode);
-        file.set_permissions(permissions).await?;
+        // enforce permission on existing files
+        let mode = nix::sys::stat::Mode::from_bits(spec.unix_mode)
+            .with_context(|| format!("failed to create unix mode: {:o}", spec.unix_mode))?;
 
-        let user = User::from_name(&spec.user)?;
-        let group = Group::from_name(&spec.group)?;
+        fchmod(file.as_fd(), mode)
+            .with_context(|| format!("setting permissions of fd to {:o}", spec.unix_mode))?;
 
-        chown(
-            spec.destination,
-            // Default uid/gid to 0. This is then wrapped around an Option again for
-            // the function.
-            Some(user.map_or(0, |user| user.uid.into())),
-            Some(group.map_or(0, |group| group.gid.into())),
-        )?;
+        // Default uid/gid to 0. This is then wrapped around an Option again for
+        // the function.
+        let user = Some(
+            User::from_name(&spec.user)
+                .context("obtaining user")?
+                .map_or(
+                    {
+                        println!("warning: defaulting uid to `0`");
 
-        file.write_all(&key_bytes).await?;
+                        0.into()
+                    },
+                    |user| user.uid.into(),
+                ),
+        );
+        let group = Some(
+            Group::from_name(&spec.group)
+                .context("obtaining group")?
+                .map_or(
+                    {
+                        println!("warning: defaulting gid to `0`");
+
+                        0.into()
+                    },
+                    |group| group.gid,
+                ),
+        );
+
+        // set permission on new files
+        fchown(&file, user, group)
+            .with_context(|| format!("setting ownership of fd to {user:?}, {group:?}"))?;
+
+        file.write_all(&key_bytes).await.context("writing to fd")?;
 
         // last key, goobye
         if spec.last {

--- a/crates/key_agent/src/main.rs
+++ b/crates/key_agent/src/main.rs
@@ -90,8 +90,8 @@ async fn main() -> Result<(), anyhow::Error> {
         let user = Some(
             User::from_name(&spec.user)
                 .context("obtaining user")?
-                .map_or(
-                    {
+                .map_or_else(
+                    || {
                         println!("warning: defaulting uid to `0`");
 
                         0.into()
@@ -102,8 +102,8 @@ async fn main() -> Result<(), anyhow::Error> {
         let group = Some(
             Group::from_name(&spec.group)
                 .context("obtaining group")?
-                .map_or(
-                    {
+                .map_or_else(
+                    || {
                         println!("warning: defaulting gid to `0`");
 
                         0.into()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential time-of-check to time-of-use (TOCTOU) vulnerability when setting key permissions and improved robustness of key file creation and ownership handling.

* **Chores**
  * Updated workspace dependency features to strengthen file-operation behavior.
  * Updated changelog documentation to reflect the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->