### PR TITLE
Use `AssertPathExists` instead of Conditional

### DIFF
--- a/runtime/module/config.nix
+++ b/runtime/module/config.nix
@@ -46,7 +46,7 @@
             done
           '';
           unitConfig = {
-            ConditionPathExists = value.path;
+            AssertPathExists = value.path;
           };
           serviceConfig = {
             Type = "simple";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Modified deployment key validation: the system now strictly requires the key path to exist, with unit deployment failing if the path is missing (previously the unit would skip operation if absent).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->