### PR TITLE
move keys @ preactivation immediately before activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - yyyy-mm-dd
 
+### Changed
+
+- The pre-activation key stage is now scheduled after the evaluation stage. The
+  rationale for this is that while iterating on evaluation errors it was often quite 
+  annoying to repeatedly enter your password for key deployment.
+
 ### Fixed
 
 - Use `AssertPathExists` instead of conditional path existence checks for key services.

--- a/crates/core/src/hive/plan.rs
+++ b/crates/core/src/hive/plan.rs
@@ -139,17 +139,6 @@ fn apply_plan(
         }));
     }
 
-    if !*no_keys
-        && matches!(
-            &goal,
-            ApplyGoal::Keys | ApplyGoal::SwitchToConfiguration(SwitchToConfigurationGoal::Switch)
-        )
-    {
-        let (pre, post) = apply_plan_keys(args, node, &target);
-        steps.extend(pre);
-        end.extend(post);
-    }
-
     if !matches!(goal, ApplyGoal::Keys) {
         steps.push(Step::Evaluate(Evaluate));
     }
@@ -182,6 +171,17 @@ fn apply_plan(
             substitute_on_destination: *substitute_on_destination,
             target: target.clone(),
         }));
+    }
+
+    if !*no_keys
+        && matches!(
+            &goal,
+            ApplyGoal::Keys | ApplyGoal::SwitchToConfiguration(SwitchToConfigurationGoal::Switch)
+        )
+    {
+        let (pre, post) = apply_plan_keys(args, node, &target);
+        steps.extend(pre);
+        end.extend(post);
     }
 
     if let ApplyGoal::SwitchToConfiguration(goal) = goal {
@@ -303,22 +303,7 @@ mod tests {
 
         assert_eq!(
             plan.steps,
-            vec![
-                Evaluate.into(),
-                Build { target: None }.into() // TODO: this was previously used in an old test, may lose
-                                              // coverage by deleting it.
-                                              // Ping { }.into(),
-                                              // PushKeyAgent { host_platform: "x86_64-linux".into(), substitute_on_destination: true, target: Target::default() }.into(),
-                                              // Keys { .. }.into(),
-                                              // crate::hive::steps::evaluate::Evaluate.into(),
-                                              // crate::hive::steps::build::Build { .. }.into(),
-                                              // crate::hive::steps::push::PushBuildOutput { .. }.into(),
-                                              // SwitchToConfiguration { .. }.into(),
-                                              // Keys {
-                                              //     filter: UploadKeyAt::PostActivation
-                                              // }
-                                              // .into(),
-            ]
+            vec![Evaluate.into(), Build { target: None }.into()]
         );
     }
 


### PR DESCRIPTION
closes #488

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Changed**
  * Reordered the pre-activation key stage to execute after the evaluation stage, reducing password prompts during key deployment iterations for a more streamlined experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/forallsys/wire/pull/490)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->